### PR TITLE
feat: Add Resource APIs for Inventory & Recipes (Issue #5)

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -34,7 +34,8 @@
     "jsonwebtoken": "^9.0.2",
     "dotenv": "^16.4.7",
     "cors": "^2.8.5",
-    "express-validator": "^7.2.0"
+    "express-validator": "^7.2.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,15 +1,31 @@
 import express, { Request, Response } from 'express';
 import dotenv from 'dotenv';
+import cors from 'cors';
+import inventoryRouter from './routes/inventory';
+import recipesRouter from './routes/recipes';
 
 dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3001;
 
+// Middleware
+app.use(cors());
 app.use(express.json());
 
+// Health check
 app.get('/', (req: Request, res: Response) => {
   res.json({ message: 'Hello from WasteNot Kitchen API!' });
+});
+
+// API Routes
+app.use('/api/inventory', inventoryRouter);
+app.use('/api/recipes', recipesRouter);
+
+// Error handling middleware
+app.use((err: Error, req: express.Request, res: express.Response, next: express.NextFunction) => {
+  console.error('Unhandled error:', err);
+  res.status(500).json({ error: 'Internal server error' });
 });
 
 app.listen(PORT, () => {

--- a/server/src/middleware/auth.middleware.ts
+++ b/server/src/middleware/auth.middleware.ts
@@ -1,0 +1,50 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+// Extend Express Request to include userId
+declare global {
+  namespace Express {
+    interface Request {
+      userId?: string;
+    }
+  }
+}
+
+export interface JWTPayload {
+  userId: string;
+  email: string;
+}
+
+/**
+ * Middleware to authenticate requests using JWT
+ * Expects Authorization header: "Bearer <token>"
+ */
+export const authenticateToken = (req: Request, res: Response, next: NextFunction): void => {
+  const authHeader = req.headers.authorization;
+  const token = authHeader && authHeader.split(' ')[1]; // Bearer TOKEN
+
+  if (!token) {
+    res.status(401).json({ error: 'Authentication required' });
+    return;
+  }
+
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    console.error('JWT_SECRET is not defined in environment variables');
+    res.status(500).json({ error: 'Server configuration error' });
+    return;
+  }
+
+  try {
+    const decoded = jwt.verify(token, secret) as JWTPayload;
+    req.userId = decoded.userId;
+    next();
+  } catch (error) {
+    if (error instanceof jwt.TokenExpiredError) {
+      res.status(401).json({ error: 'Token expired' });
+      return;
+    }
+    res.status(403).json({ error: 'Invalid token' });
+    return;
+  }
+};

--- a/server/src/routes/inventory.ts
+++ b/server/src/routes/inventory.ts
@@ -1,0 +1,169 @@
+import { Router, Request, Response } from 'express';
+import { authenticateToken } from '../middleware/auth.middleware';
+import {
+  CreateFoodItemSchema,
+  UpdateFoodItemSchema,
+  CreateBulkFoodItemsSchema,
+  DeductInventorySchema,
+} from '../schemas/inventory.schema';
+import {
+  getUserInventory,
+  getItemById,
+  createItem,
+  createBulkItems,
+  updateItem,
+  deleteItem,
+  deductIngredients,
+} from '../services/inventoryService';
+import { ZodError } from 'zod';
+
+const router = Router();
+
+/**
+ * GET /api/inventory
+ * List all items for current user (protected)
+ */
+router.get('/', authenticateToken, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId!;
+    const items = await getUserInventory(userId);
+    res.json(items);
+  } catch (error) {
+    console.error('Error fetching inventory:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * GET /api/inventory/:id
+ * Get single item (protected, owner only)
+ */
+router.get('/:id', authenticateToken, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId!;
+    const itemId = req.params.id;
+
+    const item = await getItemById(itemId, userId);
+    if (!item) {
+      res.status(404).json({ error: 'Item not found' });
+      return;
+    }
+
+    res.json(item);
+  } catch (error) {
+    console.error('Error fetching item:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * POST /api/inventory
+ * Create item with Zod validation (protected)
+ */
+router.post('/', authenticateToken, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId!;
+    const validatedData = CreateFoodItemSchema.parse(req.body);
+    const item = await createItem(userId, validatedData);
+    res.status(201).json(item);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      res.status(400).json({ error: 'Validation error', details: error.errors });
+      return;
+    }
+    console.error('Error creating item:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * POST /api/inventory/bulk
+ * Create multiple items (for receipt scan)
+ */
+router.post('/bulk', authenticateToken, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId!;
+    const validatedData = CreateBulkFoodItemsSchema.parse(req.body);
+    const items = await createBulkItems(userId, validatedData.items);
+    res.status(201).json(items);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      res.status(400).json({ error: 'Validation error', details: error.errors });
+      return;
+    }
+    console.error('Error creating bulk items:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * PUT /api/inventory/:id
+ * Update item (protected, owner only)
+ */
+router.put('/:id', authenticateToken, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId!;
+    const itemId = req.params.id;
+    const validatedData = UpdateFoodItemSchema.parse(req.body);
+
+    const item = await updateItem(itemId, userId, validatedData);
+    if (!item) {
+      res.status(404).json({ error: 'Item not found' });
+      return;
+    }
+
+    res.json(item);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      res.status(400).json({ error: 'Validation error', details: error.errors });
+      return;
+    }
+    console.error('Error updating item:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * DELETE /api/inventory/:id
+ * Delete item (protected, owner only)
+ */
+router.delete('/:id', authenticateToken, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId!;
+    const itemId = req.params.id;
+
+    const success = await deleteItem(itemId, userId);
+    if (!success) {
+      res.status(404).json({ error: 'Item not found' });
+      return;
+    }
+
+    res.status(204).send();
+  } catch (error) {
+    console.error('Error deleting item:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * POST /api/inventory/deduct
+ * Deduct ingredients with FIFO logic
+ */
+router.post('/deduct', authenticateToken, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId!;
+    const validatedData = DeductInventorySchema.parse(req.body);
+
+    const updatedInventory = await deductIngredients(userId, validatedData.usageList);
+    res.json(updatedInventory);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      res.status(400).json({ error: 'Validation error', details: error.errors });
+      return;
+    }
+    console.error('Error deducting inventory:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/server/src/routes/recipes.ts
+++ b/server/src/routes/recipes.ts
@@ -1,0 +1,164 @@
+import { Router, Request, Response } from 'express';
+import { authenticateToken } from '../middleware/auth.middleware';
+import { CreateRecipeSchema, UpdateRecipeSchema, RecipeQuerySchema } from '../schemas/recipe.schema';
+import {
+  getRecipes,
+  getRecipeById,
+  createRecipe,
+  updateRecipe,
+  deleteRecipe,
+  RecipeFilters,
+} from '../services/recipeService';
+import { ZodError } from 'zod';
+import { RecipeSource } from '@prisma/client';
+
+const router = Router();
+
+/**
+ * GET /api/recipes
+ * List with filters: ?source=X&authorId=Y&search=Z&isPublic=true
+ */
+router.get('/', async (req: Request, res: Response): Promise<void> => {
+  try {
+    // Validate query parameters
+    const validatedQuery = RecipeQuerySchema.parse(req.query);
+
+    const filters: RecipeFilters = {};
+
+    if (validatedQuery.source) {
+      filters.source = validatedQuery.source;
+    }
+
+    if (validatedQuery.authorId) {
+      filters.authorId = validatedQuery.authorId;
+    }
+
+    if (validatedQuery.search) {
+      filters.search = validatedQuery.search;
+    }
+
+    if (validatedQuery.isPublic) {
+      filters.isPublic = validatedQuery.isPublic === 'true';
+    }
+
+    const recipes = await getRecipes(filters);
+    res.json(recipes);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      res.status(400).json({ error: 'Invalid query parameters', details: error.errors });
+      return;
+    }
+    console.error('Error fetching recipes:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * GET /api/recipes/:id
+ * Get single recipe with ingredients
+ */
+router.get('/:id', async (req: Request, res: Response): Promise<void> => {
+  try {
+    const recipeId = req.params.id;
+    const recipe = await getRecipeById(recipeId);
+
+    if (!recipe) {
+      res.status(404).json({ error: 'Recipe not found' });
+      return;
+    }
+
+    res.json(recipe);
+  } catch (error) {
+    console.error('Error fetching recipe:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * POST /api/recipes
+ * Create recipe (protected, validate with Zod)
+ * Default isPublic: true for user recipes (user can override)
+ * AI-generated recipes: source: AI_GENERATED, authorId: currentUser
+ */
+router.post('/', authenticateToken, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId!;
+    const validatedData = CreateRecipeSchema.parse(req.body);
+
+    const recipe = await createRecipe(userId, validatedData);
+    res.status(201).json(recipe);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      res.status(400).json({ error: 'Validation error', details: error.errors });
+      return;
+    }
+    console.error('Error creating recipe:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * PUT /api/recipes/:id
+ * Update recipe (protected, owner only, no SYSTEM edits)
+ */
+router.put('/:id', authenticateToken, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId!;
+    const recipeId = req.params.id;
+    const validatedData = UpdateRecipeSchema.parse(req.body);
+
+    const recipe = await updateRecipe(recipeId, userId, validatedData);
+    res.json(recipe);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      res.status(400).json({ error: 'Validation error', details: error.errors });
+      return;
+    }
+    if (error instanceof Error) {
+      if (error.message === 'Cannot edit SYSTEM recipes') {
+        res.status(403).json({ error: error.message });
+        return;
+      }
+      if (error.message.startsWith('Forbidden:')) {
+        res.status(403).json({ error: error.message });
+        return;
+      }
+    }
+    console.error('Error updating recipe:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * DELETE /api/recipes/:id
+ * Delete recipe (protected, owner only, no SYSTEM deletes)
+ */
+router.delete('/:id', authenticateToken, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId!;
+    const recipeId = req.params.id;
+
+    const success = await deleteRecipe(recipeId, userId);
+    if (!success) {
+      res.status(404).json({ error: 'Recipe not found' });
+      return;
+    }
+
+    res.status(204).send();
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message === 'Cannot delete SYSTEM recipes') {
+        res.status(403).json({ error: error.message });
+        return;
+      }
+      if (error.message.startsWith('Forbidden:')) {
+        res.status(403).json({ error: error.message });
+        return;
+      }
+    }
+    console.error('Error deleting recipe:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/server/src/schemas/inventory.schema.ts
+++ b/server/src/schemas/inventory.schema.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+// Schema for creating a single food item
+export const CreateFoodItemSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(200),
+  quantity: z.number().positive('Quantity must be positive'),
+  unit: z.string().min(1, 'Unit is required').max(50),
+  expiryDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format. Use YYYY-MM-DD'),
+  category: z.string().min(1, 'Category is required').max(100),
+});
+
+// Schema for updating a food item
+export const UpdateFoodItemSchema = z.object({
+  name: z.string().min(1).max(200).optional(),
+  quantity: z.number().positive().optional(),
+  unit: z.string().min(1).max(50).optional(),
+  expiryDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  category: z.string().min(1).max(100).optional(),
+}).refine((data) => Object.keys(data).length > 0, {
+  message: 'At least one field must be provided for update',
+});
+
+// Schema for bulk create
+export const CreateBulkFoodItemsSchema = z.object({
+  items: z.array(CreateFoodItemSchema).min(1, 'At least one item is required'),
+});
+
+// Schema for deducting inventory with FIFO logic
+export const DeductInventorySchema = z.object({
+  usageList: z.array(z.object({
+    itemName: z.string().min(1, 'Item name is required'),
+    amountUsed: z.number().positive('Amount must be positive'),
+    unit: z.string().min(1, 'Unit is required'),
+  })).min(1, 'At least one usage item is required'),
+});
+
+export type CreateFoodItemInput = z.infer<typeof CreateFoodItemSchema>;
+export type UpdateFoodItemInput = z.infer<typeof UpdateFoodItemSchema>;
+export type CreateBulkFoodItemsInput = z.infer<typeof CreateBulkFoodItemsSchema>;
+export type DeductInventoryInput = z.infer<typeof DeductInventorySchema>;

--- a/server/src/schemas/recipe.schema.ts
+++ b/server/src/schemas/recipe.schema.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+import { RecipeSource } from '@prisma/client';
+
+// Schema for recipe ingredients
+const RecipeIngredientSchema = z.object({
+  name: z.string().min(1, 'Ingredient name is required').max(200),
+  amount: z.string().min(1, 'Amount is required').max(100),
+  order: z.number().int().min(0).optional(),
+});
+
+// Schema for creating a recipe
+export const CreateRecipeSchema = z.object({
+  title: z.string().min(1, 'Title is required').max(200),
+  description: z.string().min(1, 'Description is required'),
+  cookingTimeMinutes: z.number().int().positive('Cooking time must be positive'),
+  wasteReductionNote: z.string().min(1, 'Waste reduction note is required'),
+  source: z.nativeEnum(RecipeSource).optional().default(RecipeSource.USER),
+  isPublic: z.boolean().optional().default(true),
+  ingredients: z.array(RecipeIngredientSchema).min(1, 'At least one ingredient is required'),
+});
+
+// Schema for updating a recipe
+export const UpdateRecipeSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  description: z.string().min(1).optional(),
+  cookingTimeMinutes: z.number().int().positive().optional(),
+  wasteReductionNote: z.string().min(1).optional(),
+  isPublic: z.boolean().optional(),
+  ingredients: z.array(RecipeIngredientSchema).min(1).optional(),
+}).refine((data) => Object.keys(data).length > 0, {
+  message: 'At least one field must be provided for update',
+});
+
+// Schema for recipe query filters
+export const RecipeQuerySchema = z.object({
+  source: z.nativeEnum(RecipeSource).optional(),
+  authorId: z.string().optional(),
+  search: z.string().optional(),
+  isPublic: z.enum(['true', 'false']).optional(),
+});
+
+export type CreateRecipeInput = z.infer<typeof CreateRecipeSchema>;
+export type UpdateRecipeInput = z.infer<typeof UpdateRecipeSchema>;
+export type RecipeQueryInput = z.infer<typeof RecipeQuerySchema>;
+export type RecipeIngredientInput = z.infer<typeof RecipeIngredientSchema>;

--- a/server/src/services/inventoryService.ts
+++ b/server/src/services/inventoryService.ts
@@ -1,0 +1,245 @@
+import { PrismaClient, FoodItem } from '@prisma/client';
+import { CreateFoodItemInput, UpdateFoodItemInput } from '../schemas/inventory.schema';
+
+const prisma = new PrismaClient();
+
+/**
+ * Unit normalization and conversion utilities
+ * Ported from utils.ts
+ */
+export const normalizeUnit = (unit: string): string => {
+  if (!unit) return '';
+  const u = unit.toLowerCase().trim();
+  if (u === 'kgs' || u === 'kilo') return 'kg';
+  if (u === 'lbs' || u === 'pound' || u === 'pounds') return 'lbs';
+  if (u === 'liters' || u === 'liter') return 'l';
+  if (u === 'milliliters') return 'ml';
+  if (u === 'grams' || u === 'gram') return 'g';
+  if (u === 'pieces' || u === 'pc' || u === 'piece') return 'pcs';
+  if (u === 'tablespoon' || u === 'tbsp.') return 'tbsp';
+  if (u === 'teaspoon' || u === 'tsp.') return 'tsp';
+  return u;
+};
+
+const CONVERSION_RATES: Record<string, number> = {
+  g: 1, kg: 1000, oz: 28.3495, lbs: 453.592,
+  ml: 1, l: 1000, cup: 236.588, tbsp: 14.7868, tsp: 4.92892,
+  pcs: 1, bag: 1, box: 1, can: 1
+};
+
+const UNIT_TYPES: Record<string, string> = {
+  g: 'weight', kg: 'weight', oz: 'weight', lbs: 'weight',
+  ml: 'volume', l: 'volume', cup: 'volume', tbsp: 'volume', tsp: 'volume',
+  pcs: 'count', bag: 'count', box: 'count', can: 'count'
+};
+
+export const convertAmount = (amount: number, fromUnit: string, toUnit: string): number => {
+  const from = normalizeUnit(fromUnit);
+  const to = normalizeUnit(toUnit);
+
+  if (from === to) return amount;
+
+  const typeFrom = UNIT_TYPES[from];
+  const typeTo = UNIT_TYPES[to];
+
+  const isWeightToVolume = (typeFrom === 'weight' && typeTo === 'volume');
+  const isVolumeToWeight = (typeFrom === 'volume' && typeTo === 'weight');
+
+  if (typeFrom && typeTo && typeFrom !== typeTo && !isWeightToVolume && !isVolumeToWeight) {
+    console.warn(`Cannot convert ${fromUnit} to ${toUnit}`);
+    return amount;
+  }
+
+  const factorFrom = CONVERSION_RATES[from] || 1;
+  const factorTo = CONVERSION_RATES[to] || 1;
+
+  const valueInBase = amount * factorFrom;
+  return valueInBase / factorTo;
+};
+
+/**
+ * Fetch all inventory items for a user, sorted by expiry date (oldest first)
+ */
+export const getUserInventory = async (userId: string): Promise<FoodItem[]> => {
+  return prisma.foodItem.findMany({
+    where: { userId },
+    orderBy: { expiryDate: 'asc' },
+  });
+};
+
+/**
+ * Get a single food item by ID (with ownership check)
+ */
+export const getItemById = async (itemId: string, userId: string): Promise<FoodItem | null> => {
+  return prisma.foodItem.findFirst({
+    where: {
+      id: itemId,
+      userId,
+    },
+  });
+};
+
+/**
+ * Create a single food item
+ */
+export const createItem = async (userId: string, data: CreateFoodItemInput): Promise<FoodItem> => {
+  return prisma.foodItem.create({
+    data: {
+      userId,
+      name: data.name,
+      quantity: data.quantity,
+      unit: data.unit,
+      expiryDate: new Date(data.expiryDate),
+      category: data.category,
+    },
+  });
+};
+
+/**
+ * Create multiple food items in a transaction
+ */
+export const createBulkItems = async (
+  userId: string,
+  items: CreateFoodItemInput[]
+): Promise<FoodItem[]> => {
+  const createdItems = await prisma.$transaction(
+    items.map(item =>
+      prisma.foodItem.create({
+        data: {
+          userId,
+          name: item.name,
+          quantity: item.quantity,
+          unit: item.unit,
+          expiryDate: new Date(item.expiryDate),
+          category: item.category,
+        },
+      })
+    )
+  );
+  return createdItems;
+};
+
+/**
+ * Update a food item (with ownership check)
+ */
+export const updateItem = async (
+  itemId: string,
+  userId: string,
+  data: UpdateFoodItemInput
+): Promise<FoodItem | null> => {
+  // First check ownership
+  const existing = await getItemById(itemId, userId);
+  if (!existing) return null;
+
+  // Build update data
+  const updateData: any = {};
+  if (data.name !== undefined) updateData.name = data.name;
+  if (data.quantity !== undefined) updateData.quantity = data.quantity;
+  if (data.unit !== undefined) updateData.unit = data.unit;
+  if (data.expiryDate !== undefined) updateData.expiryDate = new Date(data.expiryDate);
+  if (data.category !== undefined) updateData.category = data.category;
+
+  return prisma.foodItem.update({
+    where: { id: itemId },
+    data: updateData,
+  });
+};
+
+/**
+ * Delete a food item (with ownership check)
+ */
+export const deleteItem = async (itemId: string, userId: string): Promise<boolean> => {
+  const existing = await getItemById(itemId, userId);
+  if (!existing) return false;
+
+  await prisma.foodItem.delete({
+    where: { id: itemId },
+  });
+  return true;
+};
+
+/**
+ * FIFO Inventory Deduction Logic
+ * Ported from App.tsx deductInventory function
+ */
+interface InventoryUsage {
+  itemName: string;
+  amountUsed: number;
+  unit: string;
+}
+
+export const deductIngredients = async (
+  userId: string,
+  usageList: InventoryUsage[]
+): Promise<FoodItem[]> => {
+  return prisma.$transaction(async (tx) => {
+    const inventory = await tx.foodItem.findMany({
+      where: { userId },
+      orderBy: { expiryDate: 'asc' },
+    });
+
+    const updatedInventory = [...inventory];
+
+    for (const usage of usageList) {
+      let amountRemainingToDeduct = Number(usage.amountUsed);
+      const usageUnit = usage.unit;
+      const itemName = usage.itemName.toLowerCase();
+
+      // Find all matching items, sorted by expiry (oldest first)
+      const matchingItems = updatedInventory
+        .map((item, index) => ({ ...item, originalIndex: index }))
+        .filter(item => item.name.toLowerCase() === itemName)
+        .sort((a, b) => new Date(a.expiryDate).getTime() - new Date(b.expiryDate).getTime());
+
+      // Distribute deduction across matching items (FIFO)
+      for (const match of matchingItems) {
+        if (amountRemainingToDeduct <= 0.001) break; // close enough to zero
+
+        const currentIndex = match.originalIndex;
+        const currentItem = updatedInventory[currentIndex];
+
+        // Calculate how much of this item is available, converted to the recipe's unit
+        const itemQuantityInUsageUnit = convertAmount(
+          currentItem.quantity,
+          currentItem.unit,
+          usageUnit
+        );
+
+        // We can deduct at most what is available or what is needed
+        const deductionInUsageUnit = Math.min(itemQuantityInUsageUnit, amountRemainingToDeduct);
+
+        // Convert back to item's unit to subtract
+        const deductionInItemUnit = convertAmount(deductionInUsageUnit, usageUnit, currentItem.unit);
+
+        // Update the item
+        const newQuantity = Number(Math.max(0, currentItem.quantity - deductionInItemUnit).toFixed(3));
+        updatedInventory[currentIndex] = {
+          ...currentItem,
+          quantity: newQuantity,
+        };
+
+        amountRemainingToDeduct -= deductionInUsageUnit;
+      }
+    }
+
+    // Update all items in the database and remove items with 0 quantity
+    const updatePromises = updatedInventory.map(async (item) => {
+      if (item.quantity <= 0) {
+        return tx.foodItem.delete({ where: { id: item.id } });
+      } else {
+        return tx.foodItem.update({
+          where: { id: item.id },
+          data: { quantity: item.quantity },
+        });
+      }
+    });
+
+    await Promise.all(updatePromises);
+
+    // Return updated inventory (excluding deleted items)
+    return tx.foodItem.findMany({
+      where: { userId },
+      orderBy: { expiryDate: 'asc' },
+    });
+  });
+};

--- a/server/src/services/recipeService.ts
+++ b/server/src/services/recipeService.ts
@@ -1,0 +1,216 @@
+import { PrismaClient, Recipe, RecipeIngredient, RecipeSource } from '@prisma/client';
+import { CreateRecipeInput, UpdateRecipeInput } from '../schemas/recipe.schema';
+
+const prisma = new PrismaClient();
+
+export interface RecipeWithIngredients extends Recipe {
+  ingredients: RecipeIngredient[];
+}
+
+export interface RecipeFilters {
+  source?: RecipeSource;
+  authorId?: string;
+  search?: string;
+  isPublic?: boolean;
+}
+
+/**
+ * Get recipes with optional filtering
+ */
+export const getRecipes = async (filters: RecipeFilters = {}): Promise<RecipeWithIngredients[]> => {
+  const where: any = {};
+
+  if (filters.source) {
+    where.source = filters.source;
+  }
+
+  if (filters.authorId) {
+    where.authorId = filters.authorId;
+  }
+
+  if (filters.isPublic !== undefined) {
+    where.isPublic = filters.isPublic;
+  }
+
+  if (filters.search) {
+    // Search in title or description
+    where.OR = [
+      { title: { contains: filters.search, mode: 'insensitive' } },
+      { description: { contains: filters.search, mode: 'insensitive' } },
+    ];
+  }
+
+  return prisma.recipe.findMany({
+    where,
+    include: {
+      ingredients: {
+        orderBy: { order: 'asc' },
+      },
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+};
+
+/**
+ * Get a single recipe by ID with ingredients
+ */
+export const getRecipeById = async (recipeId: string): Promise<RecipeWithIngredients | null> => {
+  return prisma.recipe.findUnique({
+    where: { id: recipeId },
+    include: {
+      ingredients: {
+        orderBy: { order: 'asc' },
+      },
+    },
+  });
+};
+
+/**
+ * Create a new recipe with ingredients in a transaction
+ * For AI-generated recipes, source should be AI_GENERATED and authorId should be the current user
+ */
+export const createRecipe = async (
+  userId: string,
+  data: CreateRecipeInput
+): Promise<RecipeWithIngredients> => {
+  return prisma.$transaction(async (tx) => {
+    // Create the recipe
+    const recipe = await tx.recipe.create({
+      data: {
+        title: data.title,
+        description: data.description,
+        cookingTimeMinutes: data.cookingTimeMinutes,
+        wasteReductionNote: data.wasteReductionNote,
+        source: data.source || RecipeSource.USER,
+        authorId: userId,
+        isPublic: data.isPublic !== undefined ? data.isPublic : true,
+      },
+    });
+
+    // Create ingredients
+    const ingredients = await Promise.all(
+      data.ingredients.map((ingredient, index) =>
+        tx.recipeIngredient.create({
+          data: {
+            recipeId: recipe.id,
+            name: ingredient.name,
+            amount: ingredient.amount,
+            order: ingredient.order !== undefined ? ingredient.order : index,
+          },
+        })
+      )
+    );
+
+    return {
+      ...recipe,
+      ingredients,
+    };
+  });
+};
+
+/**
+ * Update a recipe (with ownership and SYSTEM recipe protection)
+ */
+export const updateRecipe = async (
+  recipeId: string,
+  userId: string,
+  data: UpdateRecipeInput
+): Promise<RecipeWithIngredients | null> => {
+  // First, check if recipe exists and get ownership info
+  const existing = await prisma.recipe.findUnique({
+    where: { id: recipeId },
+  });
+
+  if (!existing) {
+    return null;
+  }
+
+  // Prevent editing SYSTEM recipes
+  if (existing.source === RecipeSource.SYSTEM) {
+    throw new Error('Cannot edit SYSTEM recipes');
+  }
+
+  // Check ownership
+  if (existing.authorId !== userId) {
+    throw new Error('Forbidden: You do not own this recipe');
+  }
+
+  return prisma.$transaction(async (tx) => {
+    // Build update data for recipe
+    const updateData: any = {};
+    if (data.title !== undefined) updateData.title = data.title;
+    if (data.description !== undefined) updateData.description = data.description;
+    if (data.cookingTimeMinutes !== undefined) updateData.cookingTimeMinutes = data.cookingTimeMinutes;
+    if (data.wasteReductionNote !== undefined) updateData.wasteReductionNote = data.wasteReductionNote;
+    if (data.isPublic !== undefined) updateData.isPublic = data.isPublic;
+
+    // Update the recipe
+    const recipe = await tx.recipe.update({
+      where: { id: recipeId },
+      data: updateData,
+    });
+
+    // If ingredients are provided, replace them
+    if (data.ingredients !== undefined) {
+      // Delete existing ingredients
+      await tx.recipeIngredient.deleteMany({
+        where: { recipeId },
+      });
+
+      // Create new ingredients
+      await Promise.all(
+        data.ingredients.map((ingredient, index) =>
+          tx.recipeIngredient.create({
+            data: {
+              recipeId: recipe.id,
+              name: ingredient.name,
+              amount: ingredient.amount,
+              order: ingredient.order !== undefined ? ingredient.order : index,
+            },
+          })
+        )
+      );
+    }
+
+    // Fetch and return the updated recipe with ingredients
+    const updatedRecipe = await tx.recipe.findUnique({
+      where: { id: recipeId },
+      include: {
+        ingredients: {
+          orderBy: { order: 'asc' },
+        },
+      },
+    });
+
+    return updatedRecipe;
+  });
+};
+
+/**
+ * Delete a recipe (with ownership and SYSTEM recipe protection)
+ */
+export const deleteRecipe = async (recipeId: string, userId: string): Promise<boolean> => {
+  const existing = await prisma.recipe.findUnique({
+    where: { id: recipeId },
+  });
+
+  if (!existing) {
+    return false;
+  }
+
+  // Prevent deleting SYSTEM recipes
+  if (existing.source === RecipeSource.SYSTEM) {
+    throw new Error('Cannot delete SYSTEM recipes');
+  }
+
+  // Check ownership
+  if (existing.authorId !== userId) {
+    throw new Error('Forbidden: You do not own this recipe');
+  }
+
+  await prisma.recipe.delete({
+    where: { id: recipeId },
+  });
+
+  return true;
+};


### PR DESCRIPTION
Implemented complete CRUD APIs for Inventory and Recipes with:

Inventory API:
- GET /api/inventory - List all items for user (sorted by expiry)
- GET /api/inventory/:id - Get single item (with ownership check)
- POST /api/inventory - Create item with Zod validation
- POST /api/inventory/bulk - Bulk create for receipt scanning
- PUT /api/inventory/:id - Update item (owner only)
- DELETE /api/inventory/:id - Delete item (owner only)
- POST /api/inventory/deduct - FIFO deduction with unit conversion

Recipes API:
- GET /api/recipes - List with filters (source, author, search, isPublic)
- GET /api/recipes/:id - Get single recipe with ingredients
- POST /api/recipes - Create recipe (protected)
- PUT /api/recipes/:id - Update recipe (owner only, no SYSTEM edits)
- DELETE /api/recipes/:id - Delete recipe (owner only, no SYSTEM deletes)

Features:
- Zod validation schemas for all endpoints
- JWT authentication middleware
- FIFO inventory deduction logic (ported from App.tsx)
- Unit conversion utilities
- Transaction support for bulk operations
- SYSTEM recipe protection
- Proper error codes (400, 401, 403, 404, 500)

Dependencies:
- Added zod@^3.22.4 to server/package.json